### PR TITLE
Added -oHostKeyAlgorithms=+ssh-rsa as ssh option.

### DIFF
--- a/elam_tool2/elam_report_generator.py
+++ b/elam_tool2/elam_report_generator.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 
 '''
-Created on Jun 27, 2017
-Last updated on May 10, 2022
-
 @author: tskanai, tokyu, keiish, koiwata, takasano, yyanomor
 '''
 from operator import is_

--- a/elam_tool2/elam_report_generator.py
+++ b/elam_tool2/elam_report_generator.py
@@ -49,7 +49,7 @@ def get_elam_report(run_dev = {}, user_pass = {}, elam_trigger = {}, elam_timeou
 
     ### Starting login each device. 
     if run_dev["run_at"] == 'client':
-        child = pexpect.spawn('ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no %s@%s' % (username, run_dev["apic_ip"]), timeout = 60)
+        child = pexpect.spawn('ssh -oHostKeyAlgorithms=+ssh-rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no %s@%s' % (username, run_dev["apic_ip"]), timeout = 60)
         print('apic login')
         child.expect('password:')
         child.sendline(password)
@@ -220,7 +220,7 @@ def elam_generate(run_dev, lc_number, asic_number, elam_trigger, user_pass, elam
         }
 
     if run_dev["run_at"] == 'client':
-        child = pexpect.spawn('ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no %s@%s' % (username, run_dev["apic_ip"]), timeout = 60)
+        child = pexpect.spawn('ssh -oHostKeyAlgorithms=+ssh-rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no %s@%s' % (username, run_dev["apic_ip"]), timeout = 60)
         child.expect('password:')
         child.sendline(password)
         child.expect('#')
@@ -234,7 +234,7 @@ def elam_generate(run_dev, lc_number, asic_number, elam_trigger, user_pass, elam
     child.expect('#')
     infra_apic_ip = re.split(r'[\n\r]+', child.before.decode('utf-8'))[1]
     #print (infra_apic_ip)
-    child.sendline('ssh -b %s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no %s@%s' % (infra_apic_ip, username, node_name))
+    child.sendline('ssh -b %s -oHostKeyAlgorithms=+ssh-rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no %s@%s' % (infra_apic_ip, username, node_name))
     child.expect('Password:')
     child.sendline(password)
     child.expect('#')
@@ -603,7 +603,7 @@ def main():
 
                     # Login APIC
                     if run_dev["run_at"] == 'client':
-                        child = pexpect.spawn('ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no %s@%s' % (username, run_dev["apic_ip"]), timeout = 60)
+                        child = pexpect.spawn('ssh -oHostKeyAlgorithms=+ssh-rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no %s@%s' % (username, run_dev["apic_ip"]), timeout = 60)
                         child.expect('password:')
                         child.sendline(password)
                         child.expect('#')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as requirements_file:
 
 setuptools.setup(
     name="elam-tool2",
-    version="1.2.0",
+    version="1.2.1",
     description="elam tool",
     author="Japan ACI Team",
     author_email="tskanai@cisco.com",


### PR DESCRIPTION
I added -oHostKeyAlgorithms=+ssh-rsa when running ssh command.
After adding it, it works well like below.
```
$ elam_report_generator
On which platform are you running the script, client or apic? [client/apic]: client
APIC IP: XXX.XXX.XXX.XXX
username: admin
password: 
<snip>
Identified as box-type switch
[jtac-bgl-p1-LF1201:LC1:ASIC0] debug platform internal tah elam asic0
[jtac-bgl-p1-LF1201:LC1:ASIC0] trigger init in-select 6 out-select 1
[jtac-bgl-p1-LF1201:LC1:ASIC0] ELAM trigger is successfully reset.
[jtac-bgl-p1-LF1201:LC1:ASIC0] No trigger is set for l2
[jtac-bgl-p1-LF1201:LC1:ASIC0] set outer ipv4 dst_ip 192.168.3.1 src_ip 192.168.0.1
[jtac-bgl-p1-LF1201:LC1:ASIC0] No trigger is set for l4
[jtac-bgl-p1-LF1201:LC1:ASIC0] Now ELAM is started on LC1 ASIC0!!!!
[jtac-bgl-p1-LF1201:LC1:ASIC0] ELAM STATUS:  ELAM STATUS, ===========, Asic 0 Slice 0 Status Triggered, Asic 0 Slice 1 Status Armed
[jtac-bgl-p1-LF1201:LC1:ASIC0] ELAM capture is successfully done!
[jtac-bgl-p1-LF1201:LC1:ASIC0] Downloading ELAM report. . .
[jtac-bgl-p1-LF1201:LC1:ASIC0] report type: ereport
[jtac-bgl-p1-LF1201:LC1:ASIC0] ELAM GENERATION Completed!
The script completed !!!!!!!!
```
Please review this request.